### PR TITLE
Show command key & name, dynamically resize window

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,19 +51,18 @@ impl From<CommandLeaf> for CommandDisplay {
     }
 }
 
-/**
- * Generates a vector of CommandDisplays from a command to display it as a list.
- */
-pub fn displayable_command_children(command: &Command) -> Vec<CommandDisplay> {
-    match command {
-        Command::Leaf(command_leaf) => vec![command_leaf.clone().into()],
-        Command::Node(command_node) => command_node
-            .children
-            .iter()
-            .map(|child| match child {
-                Command::Leaf(child_leaf) => child_leaf.clone().into(),
-                Command::Node(child_node) => child_node.clone().into(),
-            })
-            .collect(),
+impl Command {
+    pub fn displayable_children(self: &Command) -> Vec<CommandDisplay> {
+        match self {
+            Command::Leaf(command_leaf) => vec![command_leaf.clone().into()],
+            Command::Node(command_node) => command_node
+                .children
+                .iter()
+                .map(|child| match child {
+                    Command::Leaf(child_leaf) => child_leaf.clone().into(),
+                    Command::Node(child_node) => child_node.clone().into(),
+                })
+                .collect(),
+        }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,7 +52,7 @@ impl From<CommandLeaf> for CommandDisplay {
 }
 
 impl Command {
-    pub fn displayable_children(self: &Command) -> Vec<CommandDisplay> {
+    pub fn displayable_children(&self) -> Vec<CommandDisplay> {
         match self {
             Command::Leaf(command_leaf) => vec![command_leaf.clone().into()],
             Command::Node(command_node) => command_node

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,45 +1,34 @@
 use conrod::backend::glium::glium::{self, Surface};
 use conrod::backend::glium::glium::glutin::os::unix::WindowBuilderExt;
 
-use crate::commands::{Command};
 use crate::view::{handle_event, set_ui, Ids};
 use crate::event_loop::EventLoop;
 use crate::view::SpacerunEvent::{SelectCommand, CloseApplication};
-// use crate::config::SpacerunConfig;
+use crate::state::State;
 
 mod config;
 mod commands;
 mod bindings;
 mod view;
 mod event_loop;
+mod state;
 
 static FONT: &[u8] = include_bytes!("../assets/fonts/NotoSans/NotoSans-Regular.ttf");
 
-// TODO (LinuCC) Containerize state
-// pub struct SpacerunState {
-//     config: SpacerunConfig,
-//     selected_command: Command,
-//     window_height: u32,
-//     window_width: u32,
-// }
-//
 fn main() {
-
-    const WINDOW_WIDTH: u32 = 500;
-    let mut window_height: u32 = 400;
-
     // --- Setup Commands
     let config = config::load_config()
       .expect("Error loading the config. Check your configuration for inconsistencies.");
-    let mut selected_command: &Command = &config.commands;
     println!("Commands Loaded!");
     println!("{:?}", config.commands);
+
+    let mut state = State::new(config);
 
     // --- Setup Conrod
     let mut events_loop = glium::glutin::EventsLoop::new();
     let window = glium::glutin::WindowBuilder::new()
         .with_title("Spacerun")
-        .with_dimensions((WINDOW_WIDTH, window_height).into())
+        .with_dimensions((state.window_width, state.window_height).into())
         // Mainly so that the window gets opened nicely in i3, but there are
         // probably better fitting window types.
         .with_x11_window_type(glium::glutin::os::unix::XWindowType::Dialog)
@@ -51,7 +40,7 @@ fn main() {
         .with_multisampling(4);
     let display = glium::Display::new(window, context, &events_loop).unwrap();
 
-    let mut ui = conrod::UiBuilder::new([WINDOW_WIDTH as f64, window_height as f64]).build();
+    let mut ui = conrod::UiBuilder::new([state.window_width as f64, state.window_height as f64]).build();
     let mut ids = Ids::new(ui.widget_id_generator());
 
     let mut renderer = conrod::backend::glium::Renderer::new(&display).unwrap();
@@ -72,16 +61,16 @@ fn main() {
               ui.handle_event(event);
               event_loop.needs_update();
           }
-          match handle_event(&event, &selected_command) {
+          match handle_event(&event, &state) {
               Some(SelectCommand(new_selected_command)) => {
-                selected_command = new_selected_command;
+                state.select_command(new_selected_command.to_owned());
               },
               Some(CloseApplication) => break 'main,
               None => ()
           }
         }
 
-        set_ui(ui.set_widgets(), &config, &selected_command, &mut ids);
+        set_ui(ui.set_widgets(), &state, &state.selected_command, &mut ids);
 
         // Render the `Ui` and then display it on the screen.
         if let Some(primitives) = ui.draw_if_changed() {
@@ -93,10 +82,10 @@ fn main() {
 
             if let Some(render_rect) = ui.kids_bounding_box(ids.command_list) {
                 let new_window_height = render_rect.h() as u32;
-                if new_window_height != window_height {
+                if new_window_height != state.window_height {
                     println!("Updating window size.");
-                    window_height = new_window_height;
-                    display.gl_window().set_inner_size((WINDOW_WIDTH, window_height).into());
+                    state.set_window_height(new_window_height);
+                    display.gl_window().set_inner_size((state.window_width, state.window_height).into());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ fn main() {
     // --- Setup Commands
     let config = config::load_config()
       .expect("Error loading the config. Check your configuration for inconsistencies.");
-    println!("Commands Loaded!");
-    println!("{:?}", config.commands);
+    eprintln!("Commands Loaded!");
+    eprintln!("{:?}", config.commands);
 
     let mut state = State::new(config);
 
@@ -63,7 +63,7 @@ fn main() {
           }
           match handle_event(&event, &state) {
               Some(SelectCommand(new_selected_command)) => {
-                state.select_command(new_selected_command.to_owned());
+                state.selected_command = new_selected_command.to_owned();
               },
               Some(CloseApplication) => break 'main,
               None => ()
@@ -83,8 +83,8 @@ fn main() {
             if let Some(render_rect) = ui.kids_bounding_box(ids.command_list) {
                 let new_window_height = render_rect.h() as u32;
                 if new_window_height != state.window_height {
-                    println!("Updating window size.");
-                    state.set_window_height(new_window_height);
+                    eprintln!("Updating window size.");
+                    state.window_height = new_window_height;
                     display.gl_window().set_inner_size((state.window_width, state.window_height).into());
                 }
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,12 +20,4 @@ impl State {
             config: config,
         }
     }
-
-    pub fn select_command(self: &mut State, new_command: Command) -> () {
-        self.selected_command = new_command;
-    }
-
-    pub fn set_window_height(self: &mut State, window_height: u32) -> () {
-        self.window_height = window_height;
-    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,31 @@
+use crate::commands::Command;
+use crate::config::SpacerunConfig;
+
+const DEFAULT_WINDOW_WIDTH: u32 = 500;
+const DEFAULT_WINDOW_HEIGHT: u32 = 400;
+
+pub struct State {
+    pub window_width: u32,
+    pub window_height: u32,
+    pub config: SpacerunConfig,
+    pub selected_command: Command,
+}
+
+impl State {
+    pub fn new(config: SpacerunConfig) -> State {
+        State {
+            window_width: DEFAULT_WINDOW_WIDTH,
+            window_height: DEFAULT_WINDOW_HEIGHT,
+            selected_command: config.commands.to_owned(),
+            config: config,
+        }
+    }
+
+    pub fn select_command(self: &mut State, new_command: Command) -> () {
+        self.selected_command = new_command;
+    }
+
+    pub fn set_window_height(self: &mut State, window_height: u32) -> () {
+        self.window_height = window_height;
+    }
+}

--- a/src/view.rs
+++ b/src/view.rs
@@ -2,13 +2,29 @@ use std::process::Command as CliCommand;
 
 use conrod::backend::glium::glium;
 use conrod::backend::glium::glium::backend::glutin::glutin::Event;
+use conrod::{color, widget_ids};
 
 use crate::commands::Command;
+use crate::config::SpacerunConfig;
+
+widget_ids! {
+    pub struct Ids {
+        canvas,
+        command_list,
+        command_list_item_canvas[],
+        command_list_item_key_canvas[],
+        command_list_item_name_canvas[],
+        command_list_item_key_widget[],
+        command_list_item_name_widget[],
+    }
+}
 
 pub enum SpacerunEvent<'a> {
     SelectCommand(&'a Command),
     CloseApplication,
 }
+
+static DEFAULT_FONT_SIZE: u32 = 14;
 
 pub fn handle_event<'a>(event: &Event, selected_command: &'a Command) -> Option<SpacerunEvent<'a>> {
     match event {
@@ -57,5 +73,87 @@ pub fn handle_event<'a>(event: &Event, selected_command: &'a Command) -> Option<
         },
         _ => (),
     }
-    Some(SpacerunEvent::SelectCommand(selected_command))
+    None
+}
+
+// Declare the `WidgetId`s and instantiate the widgets.
+pub fn set_ui(
+    ref mut ui: conrod::UiCell,
+    config: &SpacerunConfig,
+    command: &Command,
+    ids: &mut Ids,
+) {
+    use conrod::{widget, Colorable, Positionable, Sizeable, Widget};
+
+    widget::Canvas::new()
+        .color(color::DARK_CHARCOAL)
+        .set(ids.canvas, ui);
+
+    let displayed_leafs = command.displayable_children();
+
+    // Make sure we have enough Ids for the displayed items
+    if displayed_leafs.len() != ids.command_list_item_canvas.len() {
+        ids.command_list_item_canvas
+            .resize(displayed_leafs.len(), &mut ui.widget_id_generator());
+        ids.command_list_item_key_canvas
+            .resize(displayed_leafs.len(), &mut ui.widget_id_generator());
+        ids.command_list_item_name_canvas
+            .resize(displayed_leafs.len(), &mut ui.widget_id_generator());
+        ids.command_list_item_key_widget
+            .resize(displayed_leafs.len(), &mut ui.widget_id_generator());
+        ids.command_list_item_name_widget
+            .resize(displayed_leafs.len(), &mut ui.widget_id_generator());
+    }
+
+    // Generate list displaying the commands
+    let (mut items, scrollbar) = widget::List::flow_down(displayed_leafs.len())
+        .item_size(item_height_by_font_size(config.font_size.unwrap_or(DEFAULT_FONT_SIZE)).into())
+        .scrollbar_on_top()
+        .middle_of(ids.canvas)
+        .w_of(ids.canvas)
+        .set(ids.command_list, ui);
+
+    // Generate each command item
+    while let Some(item) = items.next(ui) {
+        let i = item.i;
+
+        let text_container_canvas = widget::Canvas::new().pad(5.0);
+        let child_canvas = [
+            (
+                ids.command_list_item_key_canvas[i],
+                text_container_canvas
+                    .clone()
+                    .length_weight(0.2)
+                    .color(color::ORANGE),
+            ),
+            (
+                ids.command_list_item_name_canvas[i],
+                text_container_canvas.color(color::CHARCOAL),
+            ),
+        ];
+        let canvas = widget::Canvas::new().flow_right(&child_canvas);
+
+        item.set(canvas, ui);
+
+        widget::Text::new(&displayed_leafs[i].key)
+            .middle_of(ids.command_list_item_key_canvas[i])
+            .color(color::WHITE)
+            .font_size(config.font_size.unwrap_or(DEFAULT_FONT_SIZE))
+            .set(ids.command_list_item_key_widget[i], ui);
+
+        widget::Text::new(&displayed_leafs[i].name)
+            .mid_left_of(ids.command_list_item_name_canvas[i])
+            .color(color::WHITE)
+            .font_size(config.font_size.unwrap_or(DEFAULT_FONT_SIZE))
+            .set(ids.command_list_item_name_widget[i], ui);
+    }
+
+    if let Some(s) = scrollbar {
+        s.set(ui)
+    }
+}
+
+/// Calculate the items height by the given font size
+fn item_height_by_font_size(font_size: u32) -> u32 {
+    font_size + 20
 }


### PR DESCRIPTION
* Dynamic resize implementation is naive and is slightly delayed to the
  UI rendering, but it does the job well for now.
* Move `set_ui` to `view.rs`
* Add more sophisticated rendering of command items.
  Both key and name of the command are displayed in a row with canvas
  and child-canvases, which was _really_ hard without prior knowledge to
  get working (~8 Hrs, lul).
* Current handling of widget_ids look like a code smell, but `resize()`-ing
  the Ids to create new ones is officially documented, and seems to
  work.